### PR TITLE
responsive text + chart adjustment

### DIFF
--- a/src/cards/SingleLineCard.tsx
+++ b/src/cards/SingleLineCard.tsx
@@ -43,6 +43,12 @@ export const SingleLineCard = (data: LongData) => {
     }
 
     var options = {
+        legend: {
+            display: true,
+            labels: {
+                fontSize: window.innerWidth > 350 ? 30 : 10
+            }
+        },
         responsive: true,
         maintainAspectRatio: true,
         scales: {
@@ -51,6 +57,16 @@ export const SingleLineCard = (data: LongData) => {
                     autoSkip: true,
                     maxRotation: 50,
                     minRotation: 30,
+                    font: {
+                        size: 12
+                    }
+                }
+            },
+            y: {
+                ticks: {
+                    font: {
+                        size: 12
+                    }
                 }
             }
         },
@@ -58,14 +74,36 @@ export const SingleLineCard = (data: LongData) => {
             title: {
                 display: true,
                 text: data.data.title,
+                font: function (context: any) {
+                    var width = context.chart.width;
+                    var size = Math.round(width / 128) + 8;
+
+                    return {
+                        weight: 'bold',
+                        size: size
+                    };
+                }
             }
+
         }
     }
+
+    var plugins = [{
+        beforeDraw: function (c: any) {
+            var chartHeight = c.height;
+            c.options.scales.x.ticks.font.size = (chartHeight / 64) + 4;
+            c.options.scales.y.ticks.font.size = (chartHeight / 64) + 4;
+            c.options.legend.labels.fontsize = (chartHeight / 64) + 4;
+            //c.scales['y-axis-0'].options.x.ticks.font.size = chartHeight * 100;
+        }
+    }]
+
     return (
         <Line data={longData}
             height={500}
             width={800}
-            options={options} />
+            options={options}
+            plugins={plugins} />
 
     );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,23 @@
 .region-container {
   text-align: center;
   background-color: #EEF4FF;
-  padding: 30px;
+  /*padding: 30px;*/
+  padding: 10%;
   height: 100%;
+}
+
+.header-container {
+  text-align: center;
+  background-color: #EEF4FF;
+  /*padding: 30px;*/
+  padding-left: 10%;
+  padding-right: 10%;
+  padding-top: 5%;
+  height: 100%;
+}
+
+.vert-center {
+  padding-top: 25%;
 }
 
 
@@ -58,7 +73,8 @@
 }
 
 .summ-space {
-  margin-bottom: 35%
+  margin-top: 2%;
+  margin-bottom: 10%;
 }
 
 .narrow-container {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -301,7 +301,7 @@ export default function Home() {
                         <div className="col-1">
                         </div>
                         <div className="col-10 align-items-center">
-                            <div className="region-container">
+                            <div className="header-container">
                                 <SummaryCard data={populationData} />
                                 <SingleLineCard data={lifeExpectancy} />
                                 <br />
@@ -326,8 +326,8 @@ export default function Home() {
                         </div>
 
                         <div className="col-6">
-                            <div className="region-container">
-                                <div className="summ-space">
+                            <div className="header-container">
+                                <div className='summ-space'>
                                     <StatsCard data={weightSummary} />
                                 </div>
                                 <div className='pie'>
@@ -346,7 +346,7 @@ export default function Home() {
                         <div className="col-1">
                         </div>
                         <div className="col-10">
-                            <div className="region-container">
+                            <div className="header-container">
                                 <SummaryCard data={causeOfDeathSummary} />
                                 <BarCard data={DCDataset} />
                                 <br />
@@ -362,7 +362,7 @@ export default function Home() {
                         <div className="col-1">
                         </div>
                         <div className="col-10">
-                            <div className="region-container">
+                            <div className="header-container">
                                 <SummaryCard data={uninsuredSummaryData} />
                             </div>
                         </div>
@@ -375,7 +375,7 @@ export default function Home() {
                         <div className="col-1">
                         </div>
                         <div className="col-6">
-                            <div className="region-container">
+                            <div className="region-container vert-center">
 
                                 <MiniLineCard data={uninsuredBySubgroupData} />
                                 <br />
@@ -398,7 +398,7 @@ export default function Home() {
                         <div className="col-1">
                         </div>
                         <div className="col-10">
-                            <div className="region-container">
+                            <div className="header-container">
                                 <h4 className="header">Fertility in the US</h4>
                                 <SummaryCard data={last12MonthBirthData} />
                             </div>
@@ -413,7 +413,7 @@ export default function Home() {
                         </div>
 
                         <div className="col-10">
-                            <div className="region-container">
+                            <div className="header-container">
                                 <LineCard data={birthRateData} />
                                 <p className='source_small_font'>National Center for Health Statistics. Indicators of Health Insurance Coverage at the Time of Interview. Available from: https://data.cdc.gov/d/jb9g-gnvr.</p>
                             </div>
@@ -426,7 +426,7 @@ export default function Home() {
                         <div className="col-1">
                         </div>
                         <div className="col-10">
-                            <div className="region-container">
+                            <div className="header-container">
                                 <LineCard data={birthRateGestationalData} />
                                 <p className='source_small_font'>National Center for Health Statistics. NCHS - VSRR Quarterly provisional estimates for selected birth indicators. Available from https://data.cdc.gov/d/76vv-a7x8.</p>
                             </div>

--- a/src/pages/Regions.tsx
+++ b/src/pages/Regions.tsx
@@ -363,7 +363,7 @@ export default function Regions() {
                     <div className="col-1">
                     </div>
                     <div className="col-10">
-                        <div className="region-container">
+                        <div className="header-container">
                             <SummaryCard data={regionSumm} />
                             <DropdownButton id="dropdown-basic-button" title="Causes of Death" variant="transparent">
                                 <Dropdown.Item onClick={() => dataHandler("All causes")}>All Causes</Dropdown.Item>
@@ -458,7 +458,7 @@ export default function Regions() {
                     </div>
 
                     <div className="col-10">
-                        <div className="region-container">
+                        <div className="header-container">
 
                             <BarCard data={get3YearDCdata} />
                             <br />


### PR DESCRIPTION
I wanted to highlight these changes from the little time I had to work on this last week. While I could not get an alternative US map to work well in our framework, I added responsive label resizing for "SingleLineCard" (the first panel on home) and updated the panel presentation. It's not comprehensive, but it's a start and the solution can be implemented for other cards easily.